### PR TITLE
ci: build macOS x86_64 on macos-latest (unblock the 0.3.0 release)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
         platform:
           - { runner: ubuntu-latest,   target: x86_64 }
           - { runner: ubuntu-latest,   target: aarch64 }
-          - { runner: macos-13,        target: x86_64 }
+          - { runner: macos-latest,    target: x86_64 }   # cross-compiled on the arm64 runner (macos-13 Intel runners are retired)
           - { runner: macos-latest,    target: aarch64 }
           - { runner: windows-latest,  target: x64 }
     steps:


### PR DESCRIPTION
The `v0.3.0` release run stalled because the **macos-13 x86_64** wheel leg sat queued indefinitely — GitHub is retiring the Intel-macOS runners. Build that wheel by cross-compiling on the arm64 `macos-latest` runner instead, so the matrix no longer depends on macos-13.

After merge: delete + recreate the `v0.3.0` release off this commit so it re-runs with the fixed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)