### PR TITLE
feat(normalization): expression-token normalization helpers (0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.3.1 — 2026-06-28 — expression-token normalization helpers
+
+Adds pure-Python `normalize_skeleton`, `normalize_expression`, and `normalize_variable_token`
+to the package root (also available as `simplipy.normalization`). These canonicalize a prefix
+token sequence -- variable tokens (`v1`/`x1`, case-insensitive) to a stable `x{n}`, and numeric
+literals to a `<constant>` placeholder (skeleton form) or kept as-is (expression form) -- so two
+expressions that are "the same" up to variable renaming / constant values compare equal.
+
+Relocated from flash-ansr (behavior-identical) so the canonicalizer lives at the shared
+expression-engine leaf that downstream packages (flash-ansr, sr-data, srbf) all depend on,
+keeping holdout-matching and symbolic-recovery scoring consistent by construction. No change to
+the Rust inline backend (`simplipy._core`) or any existing API; purely additive.
+
 ## 0.3.0 — 2026-06-21 — Rust inline backend + the "numeric" engine line (MAJOR behavior change)
 
 This release rewrites SimpliPy's **inline phase** (`simplify`, the prefix/infix conversions, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "simplipy-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplipy-core"
-version = "0.3.0"              # kept in lockstep with the Python package version (pyproject.toml)
+version = "0.3.1"              # kept in lockstep with the Python package version (pyproject.toml)
 edition = "2021"
 rust-version = "1.83"          # MSRV floor of the resolved tree (pyo3 0.29 requires Rust >= 1.83)
 description = "Rust inline-phase backend for the SimpliPy prefix-expression simplifier (PyO3, the simplipy._core extension)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     ]
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.3.1"
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
 keywords = ["symbolic-regression", "simplification", "expression", "prefix", "rewriting", "rust"]

--- a/src/simplipy/__init__.py
+++ b/src/simplipy/__init__.py
@@ -5,6 +5,10 @@ from . import utils
 from .utils import (
     codify, deduplicate_rules, explicit_constant_placeholders
 )
+from . import normalization
+from .normalization import (
+    normalize_variable_token, normalize_skeleton, normalize_expression
+)
 from .asset_manager import (
     get_path, install_asset as install, uninstall_asset as uninstall, list_assets
 )

--- a/src/simplipy/normalization.py
+++ b/src/simplipy/normalization.py
@@ -1,0 +1,80 @@
+"""Expression-token normalization helpers.
+
+Canonicalize a prefix token sequence so two expressions that are "the same" compare
+equal: variable tokens (``v1``/``x1`` style, case-insensitive) are renamed to a stable
+``x{n}``, and numeric literals are folded to a ``<constant>`` placeholder (for the
+*skeleton* form) or kept (for the *expression* form).
+
+These are pure-string helpers (no engine state) so every consumer -- holdout matching,
+symbolic-recovery scoring, dataset preparation -- can reuse identical behavior. They were
+relocated here (0.3.1) from flash-ansr, behavior-identical, so the canonicalizer lives at
+the shared expression-engine leaf that flash-ansr, sr-data, and srbf all depend on.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Sequence
+
+__all__ = ["normalize_variable_token", "normalize_skeleton", "normalize_expression"]
+
+_VAR_TOKEN_PATTERN = re.compile(r"^[vx](\d+)$", re.IGNORECASE)
+
+
+def normalize_variable_token(token: str) -> tuple[str, bool]:
+    """Return ``(normalized_token, is_variable)``.
+
+    Recognizes tokens like ``v1`` or ``x2`` (case-insensitive) and returns them as
+    ``x{n}``. Non-variable tokens are returned unchanged with ``is_variable=False``.
+    """
+    match = _VAR_TOKEN_PATTERN.match(token)
+    if match:
+        return f"x{int(match.group(1))}", True
+    return token, False
+
+
+def normalize_skeleton(tokens: Sequence[str | Any] | None) -> list[str] | None:
+    """Normalize a skeleton/prefix into a list of canonical tokens.
+
+    - Variable tokens (``v1``/``x1``) are normalized to ``x{n}``.
+    - Numeric literals are converted to the ``"<constant>"`` placeholder.
+    - Existing ``"<constant>"`` / ``"<c>"`` tokens are preserved as ``"<constant>"``.
+    - Operators and other tokens are left unchanged.
+    - ``None`` maps to ``None``.
+    """
+    if tokens is None:
+        return None
+    normalized: list[str] = []
+    for token in tokens:
+        token_str = str(token)
+        normalized_token, is_var = normalize_variable_token(token_str)
+        if is_var:
+            normalized.append(normalized_token)
+            continue
+        if token_str in {"<constant>", "<c>"}:
+            normalized.append("<constant>")
+            continue
+        # numeric literal -> constant placeholder
+        try:
+            float(token_str)
+        except ValueError:
+            normalized.append(token_str)
+        else:
+            normalized.append("<constant>")
+    return normalized
+
+
+def normalize_expression(tokens: Sequence[str | Any] | None) -> list[str] | None:
+    """Normalize an expression/prefix while keeping numeric literals intact.
+
+    Converts variable tokens to canonical ``x{n}`` names but leaves numeric literals
+    untouched (so the expression form can still carry concrete float strings).
+    ``None`` maps to ``None``.
+    """
+    if tokens is None:
+        return None
+    normalized: list[str] = []
+    for token in tokens:
+        token_str = str(token)
+        normalized_token, is_var = normalize_variable_token(token_str)
+        normalized.append(normalized_token if is_var else token_str)
+    return normalized

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,0 +1,37 @@
+# test_normalization.py
+
+from simplipy import normalize_skeleton, normalize_expression, normalize_variable_token
+
+
+def test_normalize_variable_token():
+    assert normalize_variable_token("v1") == ("x1", True)
+    assert normalize_variable_token("x2") == ("x2", True)
+    assert normalize_variable_token("V3") == ("x3", True)   # case-insensitive
+    assert normalize_variable_token("X10") == ("x10", True)
+    assert normalize_variable_token("add") == ("add", False)
+    assert normalize_variable_token("3.14") == ("3.14", False)
+
+
+def test_normalize_skeleton_renames_vars_and_placeholders_constants():
+    assert normalize_skeleton(["add", "v1", "3.14"]) == ["add", "x1", "<constant>"]
+    assert normalize_skeleton(["sin", "x2"]) == ["sin", "x2"]
+    assert normalize_skeleton(["add", "x1", "<constant>"]) == ["add", "x1", "<constant>"]
+    assert normalize_skeleton(["add", "x1", "<c>"]) == ["add", "x1", "<constant>"]
+    assert normalize_skeleton(["mul", "-2", "v3"]) == ["mul", "<constant>", "x3"]
+
+
+def test_normalize_expression_keeps_literals():
+    assert normalize_expression(["add", "v1", "3.14"]) == ["add", "x1", "3.14"]
+    assert normalize_expression(["sin", "V2"]) == ["sin", "x2"]
+
+
+def test_none_passthrough():
+    assert normalize_skeleton(None) is None
+    assert normalize_expression(None) is None
+
+
+def test_renamed_skeletons_compare_equal():
+    # v-style and x-style of the same structure normalize identically
+    assert normalize_skeleton(["mul", "v1", "v2"]) == normalize_skeleton(["mul", "x1", "x2"])
+    # different concrete constants collapse to the same skeleton
+    assert normalize_skeleton(["add", "x1", "2.0"]) == normalize_skeleton(["add", "x1", "99"])


### PR DESCRIPTION
Adds pure-Python `normalize_skeleton` / `normalize_expression` / `normalize_variable_token` to the package root (and `simplipy.normalization`) and bumps **0.3.0 → 0.3.1** (pyproject + Cargo in lockstep).

**What they do:** canonicalize a prefix token sequence so expressions that are "the same" up to variable renaming / constant values compare equal — variable tokens (`v1`/`x1`, case-insensitive) → stable `x{n}`, numeric literals → `<constant>` placeholder (skeleton form) or kept (expression form).

**Why here:** relocated from flash-ansr (behavior-identical, verified on a parity battery) so the canonicalizer lives at the shared expression-engine leaf that flash-ansr, sr-data, and srbf all depend on — keeping holdout-matching and symbolic-recovery scoring consistent by construction. This is the front of the sr-data carve chain (`simplipy 0.3.1 → sr-data → flash-ansr 0.7 → srbf`).

**Scope:** purely additive — no change to the Rust `_core` or any existing API.

**Validation:** clean-venv maturin build + full suite green locally (217 passed, incl. 5 new normalization tests); behavior-identical to flash-ansr's `normalize_*` on a parity battery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)