### PR TITLE
0.7.1: find-rules config keys honored, unknown keys rejected fail-closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
-## 0.7.0 (unreleased)
+## 0.7.1 — 2026-07-21
+
+### Fixed
+- **CLI `find-rules` honors the full config**: the `prune` and `relaxed_kruskal` keys in a
+  find-rules YAML were silently ignored (`prune` fell back to the `--prune` CLI flag,
+  i.e. `False`; `relaxed_kruskal` to its default), so a config declaring
+  `prune: covered` produced an unpruned artifact that did not match its own claims.
+  Both keys are now forwarded (a config `prune:` key takes precedence over `--prune`),
+  and the CLI rejects unknown config keys fail-closed, naming the offending key — a
+  mis-spelled or unsupported key is an error, never a silent no-op (`confirm_rules:`
+  was such a silent no-op; the honored key is `confirm:`).
+- The provenance sidecar now records `relaxed_kruskal` alongside the other mine
+  parameters.
+
+## 0.7.0 — 2026-07-21
 
 Real-semantics pow alignment and the removal of the faithful dev_7-3 reproduction line:
 the package now ships ONE engine line.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "simplipy-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "astro-float",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplipy-core"
-version = "0.7.0"              # kept in lockstep with the Python package version (pyproject.toml)
+version = "0.7.1"              # kept in lockstep with the Python package version (pyproject.toml)
 edition = "2021"
 rust-version = "1.83"          # MSRV floor of the resolved tree (pyo3 0.29 requires Rust >= 1.83)
 description = "Rust inline-phase backend for the SimpliPy prefix-expression simplifier (PyO3, the simplipy._core extension)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     ]
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.7.0"
+version = "0.7.1"
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
 keywords = ["symbolic-regression", "simplification", "expression", "prefix", "rewriting", "rust"]

--- a/src/simplipy/__main__.py
+++ b/src/simplipy/__main__.py
@@ -22,7 +22,7 @@ def main(argv: str = None) -> None:
     find_simplifications_parser.add_argument('-o', '--output-file', type=str, required=True, help='Path to the output json file')
     find_simplifications_parser.add_argument('-s', '--save-every', type=int, default=100_000, help='Save the simplifications every n rules')
     find_simplifications_parser.add_argument('--reset-rules', action='store_true', help='Reset the rules before finding new ones')
-    find_simplifications_parser.add_argument('--prune', action='store_true', help='Prune redundant explicit rules after discovery (can be expensive)')
+    find_simplifications_parser.add_argument('--prune', action='store_true', help="Prune redundant explicit rules after discovery (can be expensive); a `prune:` key in the config takes precedence (false | true | 'covered')")
     find_simplifications_parser.add_argument('-v', '--verbose', action='store_true', help='Print a progress bar')
 
     # Prune-rules command
@@ -89,6 +89,21 @@ def main(argv: str = None) -> None:
 
             rule_finding_config = load_config(args.config, resolve_paths=True)
 
+            # FAIL-CLOSED config validation: a key the CLI does not forward would
+            # otherwise be ignored silently, and the mined artifact would not match
+            # what its config claims (this shipped once: `prune: covered` never ran).
+            known_keys = {
+                'max_source_pattern_length', 'max_target_pattern_length',
+                'dummy_variables', 'extra_internal_terms', 'n_samples',
+                'constants_fit_challenges', 'constants_fit_retries', 'rtol', 'atol',
+                'min_informative', 'seed', 'confirm', 'source_sample_per_length',
+                'candidate_fold_filter', 'relaxed_kruskal', 'prune', 'proposals'}
+            unknown_keys = sorted(set(rule_finding_config) - known_keys)
+            if unknown_keys:
+                print(f'Error: unknown key(s) in {args.config}: {", ".join(unknown_keys)}. '
+                      f'Known keys: {", ".join(sorted(known_keys))}', file=sys.stderr)
+                sys.exit(1)
+
             engine.find_rules(
                 max_source_pattern_length=rule_finding_config['max_source_pattern_length'],
                 max_target_pattern_length=rule_finding_config['max_target_pattern_length'],
@@ -106,11 +121,12 @@ def main(argv: str = None) -> None:
                     int(k): int(v) for k, v in
                     (rule_finding_config.get('source_sample_per_length') or {}).items()},
                 candidate_fold_filter=rule_finding_config.get('candidate_fold_filter', True),
+                relaxed_kruskal=rule_finding_config.get('relaxed_kruskal', True),
                 proposals=rule_finding_config.get('proposals', None),
                 output_file=args.output_file,
                 save_every=args.save_every,
                 reset_rules=args.reset_rules,
-                prune=args.prune,
+                prune=rule_finding_config.get('prune', args.prune),
                 verbose=args.verbose)
 
         case 'prune-rules':

--- a/src/simplipy/engine.py
+++ b/src/simplipy/engine.py
@@ -1059,6 +1059,7 @@ class SimpliPyEngine:
             confirm_seed: int,
             confirm: bool,
             candidate_fold_filter: bool,
+            relaxed_kruskal: bool,
             prune: bool | str,
             reset_rules: bool) -> dict:
         """Assemble the mined artifact's PROVENANCE record: the mine must
@@ -1098,6 +1099,7 @@ class SimpliPyEngine:
                 'rtol': rtol, 'atol': atol, 'min_informative': min_informative,
                 'seed': seed, 'mine_seed': mine_seed, 'confirm_seed': confirm_seed,
                 'confirm': confirm, 'candidate_fold_filter': candidate_fold_filter,
+                'relaxed_kruskal': relaxed_kruskal,
                 'prune': prune, 'reset_rules': reset_rules,
                 'source_sample_per_length': {str(k): int(v) for k, v in source_sample_per_length.items()},
             },
@@ -1614,7 +1616,7 @@ class SimpliPyEngine:
             rtol=rtol, atol=atol, min_informative=min_informative,
             seed=seed, mine_seed=mine_seed, confirm_seed=confirm_seed,
             confirm=confirm, candidate_fold_filter=candidate_fold_filter,
-            prune=prune, reset_rules=reset_rules)
+            relaxed_kruskal=relaxed_kruskal, prune=prune, reset_rules=reset_rules)
         if proposal_record is not None:
             # The sidecar pins the proposal batch (file + sha256 + count); the per-outcome
             # counts are filled in by the proposal pass itself (_find_rules_native).

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,3 +96,50 @@ class TestCLI:
         assert sidecar["proposals"]["count"] == 1
         assert sidecar["proposals"]["outcomes"] == {
             "certified": 1, "already_covered": 0, "rejected": 0, "duplicate": 0}
+
+    def test_find_rules_config_prune_and_relaxed_kruskal_honored(self, tmp_path) -> None:
+        """The config is the single source of truth for the mine: `prune`,
+        `relaxed_kruskal` and `confirm` keys must reach find_rules and be recorded in
+        the provenance sidecar (a key the CLI silently dropped shipped an artifact
+        that did not match its config's claims)."""
+        (tmp_path / "rules.json").write_text("[]")
+        engine_cfg = tmp_path / "engine.yaml"
+        engine_cfg.write_text(yaml.safe_dump({"operators": _SMOKE_OPERATORS, "rules": "rules.json"}))
+        mine_cfg = tmp_path / "find_rules.yaml"
+        mine_cfg.write_text(yaml.safe_dump({
+            "max_source_pattern_length": 3,
+            "max_target_pattern_length": 3,
+            "dummy_variables": 1,
+            "extra_internal_terms": ["0", "1", "<constant>"],
+            "n_samples": 256,
+            "constants_fit_retries": 16,
+            "seed": 7,
+            "confirm": False,
+            "relaxed_kruskal": False,
+            "prune": "covered",
+        }))
+        out = tmp_path / "mined.json"
+        main(["find-rules", "-e", str(engine_cfg), "-c", str(mine_cfg), "-o", str(out)])
+        params = json.load(open(str(out) + ".provenance.json"))["params"]
+        assert params["prune"] == "covered"
+        assert params["relaxed_kruskal"] is False
+        assert params["confirm"] is False
+
+    def test_find_rules_unknown_config_key_rejected(self, tmp_path, capsys) -> None:
+        """FAIL-CLOSED: an unknown find-rules config key is an error naming the key,
+        never a silent no-op."""
+        (tmp_path / "rules.json").write_text("[]")
+        engine_cfg = tmp_path / "engine.yaml"
+        engine_cfg.write_text(yaml.safe_dump({"operators": _SMOKE_OPERATORS, "rules": "rules.json"}))
+        mine_cfg = tmp_path / "find_rules.yaml"
+        mine_cfg.write_text(yaml.safe_dump({
+            "max_source_pattern_length": 2,
+            "max_target_pattern_length": 1,
+            "n_samples": 256,
+            "constants_fit_retries": 16,
+            "confirm_rules": True,
+        }))
+        with pytest.raises(SystemExit, match="1"):
+            main(["find-rules", "-e", str(engine_cfg), "-c", str(mine_cfg),
+                  "-o", str(tmp_path / "mined.json")])
+        assert "confirm_rules" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- The `prune` and `relaxed_kruskal` keys in a find-rules YAML were silently ignored; a config declaring `prune: covered` produced an unpruned artifact that did not match its own claims. Both are now forwarded (config `prune:` takes precedence over the `--prune` flag).
- The CLI rejects unknown find-rules config keys fail-closed, naming the offending key — a mis-spelled or unsupported key is an error, never a silent no-op.
- The provenance sidecar records `relaxed_kruskal` alongside the other mine parameters.

## Test plan

- [x] Two new CLI regression tests: honored keys land in provenance (`prune: covered`, `relaxed_kruskal: false`, `confirm: false`); unknown key (`confirm_rules`) exits 1 naming the key
- [x] Full `pytest tests` on the built wheel: 274 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhLKRZHNh5nNjLZhZqym9w