### PR TITLE
0.9.1: within-tier mining progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## 0.9.0 (unreleased)
+## 0.9.1 (unreleased)
+
+### Added
+- **Within-tier mining progress.** `find_rules(verbose=True)` now reports progress WHILE a length
+  tier is mining, not only at the end. The Rust miner publishes a `(sources_done, sources_total)`
+  counter (`Engine.mining_progress()` on the compiled core) that a daemon monitor polls, printing
+  `Length L: X/N sources (P%) | R src/s | ETA T | elapsed E | RSS M` at 20 / 60 / 180 s and then
+  every `SIMPLIPY_MINE_PROGRESS_INTERVAL` seconds (default 600). A long tier -- the length-5+
+  combinatorial wall where a mine can sit for days -- is no longer an opaque wait: its rate, ETA,
+  and memory are visible as it runs. Zero effect when `verbose=False`.
+
+## 0.9.0 — 2026-07-24
 
 A new simplify kernel. `simplify` is now a best-first cancellation SEARCH instead of a fixed
 cancellation order; masking (numeric literals -> `<constant>`) is separated from the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "simplipy-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "astro-float",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplipy-core"
-version = "0.9.0"              # kept in lockstep with the Python package version (pyproject.toml)
+version = "0.9.1"              # kept in lockstep with the Python package version (pyproject.toml)
 edition = "2021"
 rust-version = "1.83"          # MSRV floor of the resolved tree (pyo3 0.29 requires Rust >= 1.83)
 description = "Rust inline-phase backend for the SimpliPy prefix-expression simplifier (PyO3, the simplipy._core extension)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     ]
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.9.0"
+version = "0.9.1"
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
 keywords = ["symbolic-regression", "simplification", "expression", "prefix", "rewriting", "rust"]

--- a/rust/engine/miner.rs
+++ b/rust/engine/miner.rs
@@ -179,32 +179,40 @@ impl Engine {
         min_informative: usize,
         relaxed_kruskal: bool,
     ) -> Vec<(Vec<String>, Vec<String>)> {
+        // Publish the tier size so a driver polling `mine_progress()` sees within-tier progress
+        // while this one blocking call runs.
+        super::stats::mine_begin(sources.len() as u64);
         sources
             .par_iter()
             .enumerate()
             .filter_map(|(idx, src)| {
                 // Kruskal prune: simplify with the current rules; skip if it
                 // shortens (strict), or tighten the search bound to the simplified length (relaxed).
-                let slen = self.simplify(src, 48, None, true, false).len();
-                if slen < src.len() && !relaxed_kruskal {
-                    return None;
-                }
-                let s = seed.wrapping_add(idx as u64);
-                match self.find_rule_with_lib(
-                    src,
-                    slen,
-                    max_target,
-                    lib,
-                    challenges,
-                    retries,
-                    s,
-                    rtol,
-                    atol,
-                    min_informative,
-                ) {
-                    Ok(Some(target)) => Some((src.clone(), target)),
-                    _ => None,
-                }
+                let out = {
+                    let slen = self.simplify(src, 48, None, true, false).len();
+                    if slen < src.len() && !relaxed_kruskal {
+                        None
+                    } else {
+                        let s = seed.wrapping_add(idx as u64);
+                        match self.find_rule_with_lib(
+                            src,
+                            slen,
+                            max_target,
+                            lib,
+                            challenges,
+                            retries,
+                            s,
+                            rtol,
+                            atol,
+                            min_informative,
+                        ) {
+                            Ok(Some(target)) => Some((src.clone(), target)),
+                            _ => None,
+                        }
+                    }
+                };
+                super::stats::mine_tick(); // count the source whether or not it yielded a rule
+                out
             })
             .collect()
     }

--- a/rust/engine/stats.rs
+++ b/rust/engine/stats.rs
@@ -34,6 +34,32 @@ pub static ALL: [(&str, &AtomicU64); 11] = [
     ("nanos_mask_sort", &NANOS_MASK_SORT),
 ];
 
+// --- OFFLINE mining progress: a within-tier "sources done / total" signal a driver can poll
+// while `mine_one_length` (one blocking, rayon-parallel call) is running, so a length tier is no
+// longer an opaque black box. Process-global relaxed atomics, incremented once per source.
+pub static MINE_SOURCES_DONE: AtomicU64 = AtomicU64::new(0);
+pub static MINE_SOURCES_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// Start a tier: publish the total source count and reset the done counter.
+pub fn mine_begin(total: u64) {
+    MINE_SOURCES_TOTAL.store(total, Relaxed);
+    MINE_SOURCES_DONE.store(0, Relaxed);
+}
+
+/// One source finished (called from every rayon worker).
+#[inline]
+pub fn mine_tick() {
+    MINE_SOURCES_DONE.fetch_add(1, Relaxed);
+}
+
+/// `(done, total)` for the tier currently mining.
+pub fn mine_progress() -> (u64, u64) {
+    (
+        MINE_SOURCES_DONE.load(Relaxed),
+        MINE_SOURCES_TOTAL.load(Relaxed),
+    )
+}
+
 #[inline]
 pub fn bump(c: &AtomicU64) {
     c.fetch_add(1, Relaxed);

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -436,6 +436,14 @@ impl PyEngine {
         crate::engine::stats::reset();
     }
 
+    /// OFFLINE mining progress: `(sources_done, sources_total)` for the length tier currently
+    /// being mined by `mine_one_length`. `mine_one_length` is one blocking, rayon-parallel call,
+    /// so a driver polls this from another thread to get within-tier progress (rate / ETA)
+    /// instead of only the end-of-tier summary. `(0, 0)` before the first tier starts.
+    fn mining_progress(&self) -> (u64, u64) {
+        crate::engine::stats::mine_progress()
+    }
+
     /// OFFLINE / TEST HOOK: the value set of `tokens` over an explicit per-variable BOX --
     /// variable `i` ranges over `[los[i], his[i]]`. Returns
     /// `(has_finite, pos_inf, neg_inf, nan, fin_lo, fin_hi)`, or `None` if unevaluable.

--- a/src/simplipy/engine.py
+++ b/src/simplipy/engine.py
@@ -896,6 +896,74 @@ class SimpliPyEngine:
                 confirmed.append((source, target))
         return confirmed
 
+    def _mine_tier_with_progress(self, length: int, n_sources: int, mine_call: Callable, verbose: bool) -> Any:
+        """Run one length tier's ``mine_one_length`` (a single blocking, rayon-parallel call) while a
+        daemon thread polls the core's within-tier ``mining_progress()`` and prints a rate / ETA /
+        RSS line, so a long tier is not an opaque wait. Quick early reports (20 / 60 / 180 s), then
+        every ``SIMPLIPY_MINE_PROGRESS_INTERVAL`` seconds (default 600). No effect unless ``verbose``."""
+        if not verbose:
+            return mine_call()
+        import threading
+        import time
+        try:
+            interval = float(os.environ.get('SIMPLIPY_MINE_PROGRESS_INTERVAL', '600'))
+        except ValueError:
+            interval = 600.0
+
+        def _rss_gb() -> float:
+            try:
+                with open('/proc/self/status') as status:
+                    for line in status:
+                        if line.startswith('VmRSS:'):
+                            return int(line.split()[1]) / 1048576
+            except OSError:
+                pass
+            return float('nan')
+
+        def _fmt(sec: float) -> str:
+            if sec != sec or sec == float('inf'):
+                return '?'
+            isec = int(sec)
+            hours, isec = divmod(isec, 3600)
+            mins, isec = divmod(isec, 60)
+            return f'{hours}h{mins:02d}m' if hours else (f'{mins}m{isec:02d}s' if mins else f'{isec}s')
+
+        t0 = time.perf_counter()
+
+        def _report() -> None:
+            done, total = self._core.mining_progress()
+            total = total or n_sources
+            elapsed = time.perf_counter() - t0
+            rate = done / elapsed if elapsed > 0 else 0.0
+            eta = (total - done) / rate if rate > 0 else float('inf')
+            pct = 100.0 * done / total if total else 0.0
+            print(f'  Length {length}: {done:,}/{total:,} sources ({pct:.1f}%) | {rate:,.0f} src/s'
+                  f' | ETA {_fmt(eta)} | elapsed {_fmt(elapsed)} | RSS {_rss_gb():.1f} GB', flush=True)
+
+        stop = threading.Event()
+
+        def _monitor() -> None:
+            schedule = [20.0, 60.0, 180.0]   # quick early confirmations that it is alive + moving
+            i, last = 0, 0.0
+            while not stop.is_set():
+                elapsed = time.perf_counter() - t0
+                due = schedule[i] if i < len(schedule) else last + interval
+                if elapsed >= due:
+                    _report()
+                    last = elapsed
+                    if i < len(schedule):
+                        i += 1
+                stop.wait(5.0)
+
+        monitor = threading.Thread(target=_monitor, daemon=True)
+        monitor.start()
+        try:
+            return mine_call()
+        finally:
+            stop.set()
+            monitor.join(timeout=2.0)
+            _report()   # final within-tier line before the end-of-tier summary
+
     def _find_rules_native(
             self,
             expressions_of_length: dict[int, set[tuple[str, ...]]],
@@ -974,11 +1042,14 @@ class SimpliPyEngine:
             sources = [list(expression) for expression in sorted(expressions_of_length[length])]
             # Per-length seed block: lengths are spaced by 2^40 (far above any per-length
             # source count) so the per-source streams (seed + index) never collide.
-            found = self._core.mine_one_length(
-                sources, library, max_target_pattern_length,
-                constants_fit_challenges, constants_fit_retries,
-                mine_seed + (length << 40), rtol, atol, min_informative,
-                relaxed_kruskal)
+            found = self._mine_tier_with_progress(
+                length, len(sources),
+                lambda: self._core.mine_one_length(
+                    sources, library, max_target_pattern_length,
+                    constants_fit_challenges, constants_fit_retries,
+                    mine_seed + (length << 40), rtol, atol, min_informative,
+                    relaxed_kruskal),
+                verbose)
             if found and X_confirm is not None:
                 n_mined = len(found)
                 found = self._confirm_mined_rules(


### PR DESCRIPTION
Adds within-tier progress reporting to the offline miner so a length tier is no longer an opaque wait.

`mine_one_length` is one blocking, rayon-parallel call; `find_rules` previously printed only an end-of-tier summary, so a mine sitting for days on the length-5+ combinatorial wall gave no sign of life or ETA. Now:

- The Rust miner increments a process-global `(sources_done, sources_total)` counter per source, exposed as `Engine.mining_progress()`.
- `find_rules(verbose=True)` runs a daemon monitor that polls it and prints `Length L: X/N sources (P%) | R src/s | ETA T | elapsed E | RSS M` at 20 / 60 / 180 s, then every `SIMPLIPY_MINE_PROGRESS_INTERVAL` seconds (default 600).
- Zero effect when `verbose=False`; the mine result is byte-identical (relaxed atomic, no control-flow effect).

Smoke-verified on a length-4 tier (73,854 sources): the 20 s report showed 93.6% done, 3,455 src/s, ETA. 71 Rust + 284 Python tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhLKRZHNh5nNjLZhZqym9w